### PR TITLE
feat: streamline release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,6 +11,17 @@ jobs:
       contents: write
 
     steps:
+      - name: Verify dispatch token
+        env:
+          EXPECTED_TOKEN: ${{ secrets.CARBON_MCP_DISPATCH_TOKEN }}
+          RECEIVED_TOKEN: ${{ github.event.client_payload.token }}
+        run: |
+          if [ "$RECEIVED_TOKEN" != "$EXPECTED_TOKEN" ]; then
+            echo "❌ Invalid dispatch token — aborting."
+            exit 1
+          fi
+          echo "✅ Dispatch token verified."
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,52 @@
+name: Create Release
+
+on:
+  repository_dispatch:
+    types: [new-release]
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set version
+        id: version
+        run: |
+          VERSION="${{ github.event.client_payload.version }}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      # ── Build the carbon-builder zip ──────────────────────────────────────
+      - name: Create carbon-builder zip
+        run: |
+          mkdir -p dist
+          zip -r dist/carbon-builder.zip public/skills/carbon-builder
+
+      # ── Tag and publish release with the approved notes from internal ──────
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        run: |
+          git tag -a "${{ steps.version.outputs.tag }}" \
+            -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Release ${{ steps.version.outputs.tag }}
+          body: ${{ github.event.client_payload.body }}
+          draft: false
+          prerelease: false
+          files: dist/carbon-builder.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zip-carbon-builder.yml
+++ b/.github/workflows/zip-carbon-builder.yml
@@ -1,0 +1,35 @@
+name: Zip carbon-builder
+
+on:
+  push:
+    paths:
+      - 'public/skills/carbon-builder/**'
+      - '.github/workflows/zip-carbon-builder.yml'
+  workflow_dispatch:
+
+jobs:
+  zip-carbon-builder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create zip archive
+        run: |
+          mkdir -p dist
+          zip -r dist/carbon-builder.zip public/skills/carbon-builder
+
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: carbon-builder.zip
+          path: dist/carbon-builder.zip
+
+      - name: Attach zip to GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/carbon-builder.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Changelog

Complimentary PR to finalize the release flow.


**New**
- `create-release.yml` -> receives final release notes to automatically publish
- `zip-carbon-builder.yml` -> zips and includes the carbon-builder skill with the new release

**Changed**

- `create-release-tag.yml` -> `create-release-notes.yml`
- `version-update.yml` -> `release.yml`

#### Testing / Reviewing
Verify with Github Actions docs that this should work.
